### PR TITLE
chore: standardize user role casing

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,7 +12,7 @@ export const assignDefaultRoleAndCreateUserDocument = functions.auth.user()
   .onCreate(async (user: functions.auth.UserRecord) => {
     try {
       const customClaims = {
-        roles: ["client"],
+        roles: [UserRole.CLIENT],
       };
 
       // Set custom user claims on the Firebase Auth user
@@ -42,7 +42,7 @@ export const assignDefaultRoleAndCreateUserDocument = functions.auth.user()
       await userRef.set({
         id: user.uid,
         email: user.email,
-        roles: ["client"], // Store roles in Firestore for easier querying/display
+        roles: [UserRole.CLIENT], // Store roles in Firestore for easier querying/display
         name: user.displayName || "New User",
         profilePictureUrl: user.photoURL || "",
         isDemoAccount: false,

--- a/types.ts
+++ b/types.ts
@@ -1,9 +1,9 @@
 
 export enum UserRole {
-  CLIENT = 'CLIENT',
-  THERAPIST = 'THERAPIST',
-  CLINIC_OWNER = 'CLINIC_OWNER',
-  ADMIN = 'ADMIN',
+  CLIENT = 'client',
+  THERAPIST = 'therapist',
+  CLINIC_OWNER = 'clinic_owner',
+  ADMIN = 'admin',
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- use lowercase identifiers in `UserRole` enum
- reference `UserRole.CLIENT` when assigning default roles in Cloud Functions
- confirm Firestore rules already use the lowercase identifiers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TherapistDashboardPage.tsx: JSX element 'div' has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_68936bfdff1c832b8d67c50659675764