### PR TITLE
fix: rename SwipableTherapistCard to SwipeableTherapistCard

### DIFF
--- a/components/therapist-finder/SwipeableTherapistCard.tsx
+++ b/components/therapist-finder/SwipeableTherapistCard.tsx
@@ -4,12 +4,12 @@ import { MapPinIcon, PlayIcon, InformationCircleIcon, FlowerTickIcon } from '../
 import { useTranslation } from '../../hooks/useTranslation';
 import { Button } from '../common/Button';
 
-interface SpotlightTherapistCardProps {
+interface SwipeableTherapistCardProps {
   therapist: Therapist;
   onViewProfile: () => void;
 }
 
-const SpotlightTherapistCardComponent: React.FC<SpotlightTherapistCardProps> = ({ therapist, onViewProfile }) => {
+const SwipeableTherapistCardComponent: React.FC<SwipeableTherapistCardProps> = ({ therapist, onViewProfile }) => {
   const [showVideo, setShowVideo] = useState(false);
   const { t, direction } = useTranslation();
 
@@ -115,4 +115,4 @@ const SpotlightTherapistCardComponent: React.FC<SpotlightTherapistCardProps> = (
   );
 };
 
-export const SpotlightTherapistCard = React.memo(SpotlightTherapistCardComponent);
+export const SwipeableTherapistCard = React.memo(SwipeableTherapistCardComponent);

--- a/pages/TherapistFinderPage.tsx
+++ b/pages/TherapistFinderPage.tsx
@@ -4,7 +4,7 @@ import { Therapist, UserRole } from '../types';
 import { APP_NAME, AVAILABILITY_OPTIONS, SPECIALIZATIONS_LIST, LANGUAGES_LIST } from '../constants';
 import { TherapistDetailModal } from '../components/TherapistDetailModal';
 import { Button } from '../components/common/Button';
-import { SpotlightTherapistCard } from '../components/therapist-finder/SwipableTherapistCard';
+import { SwipeableTherapistCard } from '../components/therapist-finder/SwipeableTherapistCard';
 import { TherapistCard } from '../components/TherapistCard';
 import { TherapistMapView } from '../components/therapist-finder/TherapistMapView';
 import { Modal } from '../components/common/Modal';
@@ -489,7 +489,7 @@ export const TherapistFinderPage: React.FC = () => {
               key={currentTherapistForSpotlight.id + currentIndex}
               className={`w-full h-full ${getCardAnimationClass()}`}
             >
-                <SpotlightTherapistCard
+                <SwipeableTherapistCard
                     therapist={currentTherapistForSpotlight}
                     onViewProfile={() => handleViewProfile(currentTherapistForSpotlight)}
                 />


### PR DESCRIPTION
## Summary
- rename SwipableTherapistCard to SwipeableTherapistCard
- update TherapistFinderPage to use renamed component

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68937816035c832bb1a289c94c26f918