### PR TITLE
fix: include zero coordinates in therapist map

### DIFF
--- a/components/therapist-finder/TherapistMapView.tsx
+++ b/components/therapist-finder/TherapistMapView.tsx
@@ -40,13 +40,22 @@ export const TherapistMapView: React.FC<TherapistMapViewProps> = ({ therapists, 
         }
       });
 
-      const validTherapists = therapists.filter(t => t.locations && t.locations.some(l => l.lat && l.lng));
+      const validTherapists = therapists.filter(
+        t =>
+          t.locations &&
+          t.locations.some(
+            l => typeof l.lat === 'number' && typeof l.lng === 'number'
+          )
+      );
 
       if (validTherapists.length > 0) {
         const bounds = L.latLngBounds([] as LatLngTuple[]);
         validTherapists.forEach(therapist => {
           therapist.locations.forEach(location => {
-            if (location.lat && location.lng) {
+            if (
+              typeof location.lat === 'number' &&
+              typeof location.lng === 'number'
+            ) {
               const marker = (L.marker([location.lat, location.lng]) as LeafletMarkerClass).addTo(mapInstance.current!);
               
               const popupContent = document.createElement('div');


### PR DESCRIPTION
## Summary
- use explicit number checks for therapist location coordinates so markers render even at 0 latitude or longitude

## Testing
- `node -e "const therapists=[{name:'A',locations:[{lat:0,lng:30},{lat:1,lng:1}]},{name:'B',locations:[{lat:null,lng:2}]},{name:'C',locations:[{lat:0,lng:0}]},{name:'D',locations:[]}]; const valid=therapists.filter(t=>t.locations&&t.locations.some(l=>typeof l.lat==='number'&&typeof l.lng==='number')); console.log(valid);"`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: pages/dashboard/therapist/TherapistDashboardPage.tsx(266,18): error TS17008: JSX element 'div' has no corresponding closing tag.)*

------
https://chatgpt.com/codex/tasks/task_e_6893781abdc8832bb19a8eeba78ff1e3