### PR TITLE
feat: add security rules for therapist and clinic data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -194,8 +194,31 @@ service cloud.firestore {
                      resource.data.roles.hasAny(["therapist", "clinic_owner"]) &&
                      request.query.keys().hasOnly([
                          'id', 'name', 'profilePictureUrl', 'photos', 'amenities', 'operatingHours',
-                         'services', 'address', 'lat', 'lng', 'description', 'isVerified'
+                     'services', 'address', 'lat', 'lng', 'description', 'isVerified'
                      ]);
+    }
+
+    match /therapistsData/{therapistId} {
+      // Admins have full access; therapists can manage their own data
+      allow read, write: if isAdmin() || (isTherapist() && isOwner(therapistId));
+
+      match /membershipHistory/{entryId} {
+        // Admins or the owning therapist can access membership history
+        allow read, write: if isAdmin() || (isTherapist() && isOwner(therapistId));
+      }
+    }
+
+    match /clinicsData/{clinicId} {
+      // Admins have full access; clinic owners can manage their own clinic data
+      allow read, write: if isAdmin() || (isClinicOwner() &&
+        (resource.data.ownerId == request.auth.uid || request.resource.data.ownerId == request.auth.uid));
+    }
+
+    match /activityLog/{logId} {
+      // Admins have full access; users can access their own activity logs
+      allow read, write: if isAdmin() ||
+        (isSignedIn() && (resource.data.userId == request.auth.uid ||
+          request.resource.data.userId == request.auth.uid));
     }
 
     match /clinicSpaces/{clinicSpaceId} {


### PR DESCRIPTION
## Summary
- add role and ownership-based rules for `therapistsData`
- secure `clinicsData` and `activityLog` collections
- include nested membership history rules for therapists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `firebase deploy --only firestore:rules` *(fails: Failed to authenticate, have you run firebase login?)*

------
https://chatgpt.com/codex/tasks/task_e_6893764938e4832bbde0061eaf60f789