### PR TITLE
feat: add admin site management tab

### DIFF
--- a/components/dashboard/shared/DashboardLayout.tsx
+++ b/components/dashboard/shared/DashboardLayout.tsx
@@ -38,10 +38,11 @@ const clinicNavItems: NavItem[] = [
 ];
 
 const adminNavItems: NavItem[] = [
-  { path: '', labelKey: 'dashboardTherapistsValidationTab', icon: <UsersIcon /> }, 
+  { path: '', labelKey: 'dashboardTherapistsValidationTab', icon: <UsersIcon /> },
   { path: 'clinic-approval', labelKey: 'dashboardClinicApprovalTab', icon: <BuildingOfficeIcon /> },
   { path: 'communication', labelKey: 'dashboardCommunicationTab', icon: <ChatBubbleLeftRightIcon /> },
-  { path: 'activity-log', labelKey: 'dashboardActivityLogTab', icon: <DocumentTextIcon /> }
+  { path: 'activity-log', labelKey: 'dashboardActivityLogTab', icon: <DocumentTextIcon /> },
+  { path: 'site-management', labelKey: 'dashboardSiteManagementTab', icon: <CogIcon /> }
 ];
 
 


### PR DESCRIPTION
## Summary
- add Site Management tab to admin dashboard navigation

## Testing
- `npm run build` *(fails: pages/dashboard/therapist/TherapistDashboardPage.tsx:266,18 - JSX element 'div' has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_68937d9d4630832b8f524f5fd0ca0c68