### PR TITLE
feat: add dynamic clinic analytics

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -262,6 +262,7 @@
   "totalTherapistConnectionsLabel": "استفسارات المعالجين",
   "viaPlatformFeaturesLabel": "عبر ميزات المنصة",
   "viewTrendsOverTimePlaceholder": "سيتم عرض الرسوم البيانية والتحليلات التفصيلية هنا قريبًا.",
+  "errorLoadingAnalytics": "تعذر تحميل التحليلات.",
   "editPersonalInformationTitle": "تعديل المعلومات الشخصية",
   "managePasswordButton": "إدارة كلمة المرور",
   "deleteYourAccountButton": "حذف حسابك",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -262,6 +262,7 @@
   "totalTherapistConnectionsLabel": "Therapist Inquiries",
   "viaPlatformFeaturesLabel": "via platform features",
   "viewTrendsOverTimePlaceholder": "Graphs and detailed analytics will be shown here soon.",
+  "errorLoadingAnalytics": "Unable to load analytics.",
   "editPersonalInformationTitle": "Edit Personal Information",
   "managePasswordButton": "Manage Password",
   "deleteYourAccountButton": "Delete Your Account",


### PR DESCRIPTION
## Summary
- replace placeholder metrics with Firestore-driven analytics for clinic owner dashboard
- show profile views and therapist connections dynamically with loading and error states
- add localized error message for analytics retrieval

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TherapistDashboardPage.tsx(266,18): JSX element 'div' has no corresponding closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_6893813e1f48832baccba451fa027bcb