### PR TITLE
Add therapist analytics tab

### DIFF
--- a/components/dashboard/shared/DashboardLayout.tsx
+++ b/components/dashboard/shared/DashboardLayout.tsx
@@ -24,9 +24,10 @@ interface NavItem {
 }
 
 const therapistNavItems: NavItem[] = [
-  { path: '', labelKey: 'dashboardMyProfileTab', icon: <BriefcaseIcon />, therapistOnly: true }, 
+  { path: '', labelKey: 'dashboardMyProfileTab', icon: <BriefcaseIcon />, therapistOnly: true },
   { path: 'licenses', labelKey: 'dashboardLicensesTab', icon: <DocumentDuplicateIcon />, therapistOnly: true},
-  { path: 'space-rental', labelKey: 'dashboardSpaceRentalTab', icon: <BuildingOfficeIcon />, therapistOnly: true}, 
+  { path: 'analytics', labelKey: 'dashboardAnalyticsTab', icon: <ChartBarIcon />, therapistOnly: true},
+  { path: 'space-rental', labelKey: 'dashboardSpaceRentalTab', icon: <BuildingOfficeIcon />, therapistOnly: true},
   { path: 'settings', labelKey: 'dashboardSettingsTab', icon: <CogIcon />, therapistOnly: true },
 ];
 

--- a/pages/dashboard/therapist/TherapistDashboardPage.tsx
+++ b/pages/dashboard/therapist/TherapistDashboardPage.tsx
@@ -276,8 +276,8 @@ const TherapistProfileTabContent: React.FC = () => {
                         {LANGUAGES_LIST.map((lang: string) => <option key={lang} value={lang}>{lang}</option>)}
                     </select>
                     <p className="mt-1 text-xs text-gray-500">{t('multiSelectHint')}</p>
-                }
-                 {formData.languages?.includes('Other') && (
+                </div>
+                {formData.languages?.includes('Other') && (
                     <InputField label={t('otherLanguagesLabel')} id="otherLanguages" name="otherLanguages" value={otherLanguagesText} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setOtherLanguagesText(e.target.value)} description={t('otherLanguagesHint')} />
                 )}
 
@@ -529,6 +529,82 @@ const SpaceFilterModal: React.FC<SpaceFilterModalProps> = ({ isOpen, onClose, cu
                 </div>
             </div>
         </Modal>
+    );
+};
+
+const TherapistAnalyticsTabContent: React.FC = () => {
+    usePageTitle('dashboardAnalyticsTab');
+    const { t } = useTranslation();
+    const { therapistData } = useOutletContext<OutletContextType>();
+    const [profileViews, setProfileViews] = useState<number>(0);
+    const [likes, setLikes] = useState<number>(0);
+    const [inquiriesCount, setInquiriesCount] = useState<number>(0);
+    const [averageRating, setAverageRating] = useState<number>(0);
+
+    useEffect(() => {
+        const fetchAnalytics = async () => {
+            if (!therapistData?.id) return;
+            try {
+                const therapistDoc = await getDoc(doc(db, 'therapistsData', therapistData.id));
+                if (therapistDoc.exists()) {
+                    const data = therapistDoc.data();
+                    setProfileViews(data?.profileViews || 0);
+                    setLikes(data?.likes || 0);
+                }
+
+                const inquiriesSnapshot = await getDocs(
+                    query(
+                        collection(db, 'userInquiries'),
+                        where('targetId', '==', therapistData.id),
+                        where('targetType', '==', 'therapist')
+                    )
+                );
+                setInquiriesCount(inquiriesSnapshot.size);
+
+                const reviewsSnapshot = await getDocs(collection(db, 'therapistsData', therapistData.id, 'reviews'));
+                if (!reviewsSnapshot.empty) {
+                    let total = 0;
+                    reviewsSnapshot.forEach(doc => {
+                        const rating = doc.data().rating;
+                        if (typeof rating === 'number') total += rating;
+                    });
+                    setAverageRating(total / reviewsSnapshot.size);
+                } else {
+                    setAverageRating(0);
+                }
+            } catch (error) {
+                console.error('Error fetching analytics:', error);
+            }
+        };
+        fetchAnalytics();
+    }, [therapistData?.id]);
+
+    return (
+        <div className="space-y-6">
+            <h3 className="text-xl font-semibold text-accent">{t('therapistEngagementMetricsTitle')}</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="bg-gray-50/50 p-6 rounded-lg shadow">
+                    <h4 className="text-lg font-medium text-textOnLight">{t('totalProfileViews')}</h4>
+                    <p className="text-3xl font-bold text-accent">{profileViews}</p>
+                </div>
+                <div className="bg-gray-50/50 p-6 rounded-lg shadow">
+                    <h4 className="text-lg font-medium text-textOnLight">{t('estimatedConnections')}</h4>
+                    <p className="text-3xl font-bold text-accent">{inquiriesCount}</p>
+                </div>
+                <div className="bg-gray-50/50 p-6 rounded-lg shadow">
+                    <h4 className="text-lg font-medium text-textOnLight">{t('totalProfileLikes')}</h4>
+                    <p className="text-3xl font-bold text-accent">{likes}</p>
+                </div>
+                <div className="bg-gray-50/50 p-6 rounded-lg shadow">
+                    <h4 className="text-lg font-medium text-textOnLight">{t('averageRating')}</h4>
+                    <p className="text-3xl font-bold text-accent">{averageRating.toFixed(1)}</p>
+                </div>
+            </div>
+            <div className="bg-gray-50/50 p-6 rounded-lg shadow text-center">
+                <InformationCircleIcon className="w-12 h-12 text-gray-400 mx-auto mb-3" />
+                <p className="text-gray-600">{t('therapistViewTrendsPlaceholder')}</p>
+            </div>
+        </div>
     );
 };
 
@@ -1148,6 +1224,7 @@ export const TherapistDashboardRoutes = () => (
         <Route element={<TherapistDashboardPageShell />}>
             <Route index element={<TherapistProfileTabContent />} />
             <Route path="licenses" element={<TherapistLicensesTabContent />} />
+            <Route path="analytics" element={<TherapistAnalyticsTabContent />} />
             <Route path="space-rental" element={<TherapistSpaceRentalTabContent />} />
             <Route path="settings" element={<TherapistSettingsTabContent />} />
         </Route>


### PR DESCRIPTION
## Summary
- add analytics nav item for therapists
- show profile metrics and inquiries with new analytics tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists)*

------
https://chatgpt.com/codex/tasks/task_e_689385f44fd8832ba8a8d09e4ce736f9