### PR TITLE
Consolidate clinic read rule in Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -186,14 +186,8 @@ service cloud.firestore {
       // Therapists and Clients can read public clinic information.
       // Move sensitive clinic fields to another collection or expose sanitized data via Cloud Functions if required.
       allow read: if (isTherapist() || isClient()) &&
-
-                     resource.data.roles.hasAny(["therapist", "clinic_owner"]);
-=======
-                     resource.data.roles.hasAny(["therapist", "clinic_owner"]) &&
-                     request.query.keys().hasOnly([
-                         'id', 'name', 'profilePictureUrl', 'photos', 'amenities', 'operatingHours',
-                     'services', 'address', 'lat', 'lng', 'description', 'isVerified'
-                     ]);
+                     resource.data.roles.hasAny(["therapist","clinic_owner"]) &&
+                     request.query.keys().hasOnly(['id','name','profilePictureUrl','photos','amenities','operatingHours','services','address','lat','lng','description','isVerified']);
 
     }
 


### PR DESCRIPTION
## Summary
- merge conflicting `allow read` rules for clinics into single rule with whitelist of fields

## Testing
- `npx -y firebase-tools emulators:exec --only firestore --project demo-test "echo hi"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68945f69f1c8832b8680d9d20694c588