### PR TITLE
feat: add French language support

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -24,10 +24,30 @@ export const Navbar: React.FC = () => {
     navigate('/login');
   }
 
+  const getNextLanguage = (lang: string) => {
+    if (lang === 'en') return 'ar';
+    if (lang === 'ar') return 'fr';
+    return 'en';
+  };
+
   const toggleLanguage = () => {
-    setLanguage(language === 'en' ? 'ar' : 'en');
+    setLanguage(getNextLanguage(language));
     setIsMobileMenuOpen(false);
   };
+
+  const languageLabels: Record<string, string> = {
+    en: t('english'),
+    ar: t('arabic'),
+    fr: t('french'),
+  };
+
+  const languageAbbreviations: Record<string, string> = {
+    en: 'EN',
+    ar: 'AR',
+    fr: 'FR',
+  };
+
+  const nextLanguage = getNextLanguage(language);
 
   const publicLinks = [
     { path: '/find', labelKey: 'findTherapists' },
@@ -122,9 +142,9 @@ export const Navbar: React.FC = () => {
               size="sm"
               onClick={toggleLanguage}
               className="!px-3 !py-2 !text-textOnLight/70 hover:!text-accent hover:!bg-accent/10"
-              title={language === 'en' ? 'Switch to Arabic' : 'Switch to English'}
+              title={`Switch to ${languageLabels[nextLanguage]}`}
             >
-              {language === 'en' ? t('arabic') : t('english')}
+              {languageLabels[nextLanguage]}
             </Button>
             {isAuthenticated && user ? (
               <div className="relative group">
@@ -167,9 +187,9 @@ export const Navbar: React.FC = () => {
               size="sm"
               onClick={toggleLanguage}
               className="!p-2 !text-textOnLight/70 hover:!text-accent hover:!bg-accent/10"
-              title={language === 'en' ? 'Switch to Arabic' : 'Switch to English'}
+              title={`Switch to ${languageLabels[nextLanguage]}`}
             >
-              {language === 'en' ? 'AR' : 'EN'}
+              {languageAbbreviations[nextLanguage]}
             </Button>
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, ReactNode, useEffect, useCallback, useContext } from 'react';
 import toast from 'react-hot-toast';
 
-type Language = 'en' | 'ar';
+type Language = 'en' | 'ar' | 'fr';
 type Direction = 'ltr' | 'rtl';
 
 export interface LanguageContextType {
@@ -16,7 +16,8 @@ export const LanguageContext = createContext<LanguageContextType | undefined>(un
 
 const translations: Record<Language, Record<string, string>> = {
   en: {},
-  ar: {}
+  ar: {},
+  fr: {}
 };
 
 // This function will now be more resilient and not throw a blocking error.
@@ -60,7 +61,11 @@ export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }
     const loadInitialTranslations = async () => {
       console.log("LanguageProvider: Starting to load initial translations...");
       // Promise.all will now complete even if one of the fetches fails.
-      await Promise.all([loadTranslations('en'), loadTranslations('ar')]);
+      await Promise.all([
+        loadTranslations('en'),
+        loadTranslations('ar'),
+        loadTranslations('fr'),
+      ]);
       setIsLoaded(true);
       console.log("LanguageProvider: Finished loading initial translations attempt. isLoaded:", true);
     };

--- a/hooks/__tests__/useTranslation.test.tsx
+++ b/hooks/__tests__/useTranslation.test.tsx
@@ -26,6 +26,9 @@ describe('useTranslation', () => {
       if (path.includes('ar.json')) {
         return Promise.resolve({ ok: true, json: async () => ({}) }) as any;
       }
+      if (path.includes('fr.json')) {
+        return Promise.resolve({ ok: true, json: async () => ({}) }) as any;
+      }
       return Promise.reject(new Error('Unknown URL'));
     });
 


### PR DESCRIPTION
## Summary
- extend language context to load French translations
- allow cycling through English, Arabic and French in the navbar
- update translation tests for French locale

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68945aabbd10832b9e90b0e3e17412b1