### PR TITLE
fix analytics tab and reconcile dashboard merge

### DIFF
--- a/pages/dashboard/clinic-owner/ClinicOwnerDashboardPage.tsx
+++ b/pages/dashboard/clinic-owner/ClinicOwnerDashboardPage.tsx
@@ -62,7 +62,7 @@ interface AccordionSectionProps {
     badgeColor?: string;
 }
 const AccordionSection: React.FC<AccordionSectionProps> = ({ titleKey, icon, isOpen, onClick, children, badgeText, badgeColor }) => {
-    const { t } = useTranslation();
+    const { t, direction } = useTranslation();
     return (
         <div className="border border-gray-200 rounded-lg overflow-hidden">
             <button


### PR DESCRIPTION
## Summary
- include `direction` from translation hook in Dashboard accordion
- keep Firestore-powered ClinicAnalyticsTabContent with Chart.js line chart

## Testing
- `npm test -- --run`
- `npm run build` *(fails: components/dashboard/shared/DashboardLayout.tsx(49,3): error TS1005: ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68948971dcc4832b98645cdb573b85bd