### PR TITLE
chore: remove import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,33 +8,11 @@
     <!-- PWA Manifest and theme color are now injected by vite-plugin-pwa -->
     <link rel="icon" href="/logo.png" type="image/png">
     
-<script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^18.2.0",
-    "react-dom/": "https://esm.sh/react-dom@^18.2.0/",
-    "@fortawesome/fontawesome-free/": "https://esm.sh/@fortawesome/fontawesome-free@^6.5.2/",
-    "leaflet/": "https://esm.sh/leaflet@^1.9.4/",
-    "react/": "https://esm.sh/react@^18.2.0/",
-    "firebase/": "https://esm.sh/firebase@^10.12.2/",
-    "react-router-dom": "https://esm.sh/react-router-dom@^6.22.3",
-    "leaflet": "https://esm.sh/leaflet@^1.9.4",
-    "@tanstack/react-query": "https://esm.sh/@tanstack/react-query@^5.51.1",
-    "react-hook-form": "https://esm.sh/react-hook-form@^7.52.1",
-    "react-hot-toast": "https://esm.sh/react-hot-toast@^2.4.1",
-    "vite": "https://esm.sh/vite@^5.2.0",
-    "@vitejs/plugin-react": "https://esm.sh/@vitejs/plugin-react@^4.2.1",
-    "path": "https://esm.sh/path@^0.12.7",
-    "url": "https://esm.sh/url@^0.11.4",
-    "vite-plugin-pwa": "https://esm.sh/vite-plugin-pwa@^0.20.0"
-  }
-}
-</script>
 <link rel="stylesheet" href="/index.css">
 </head>
 <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+<script type="module" src="/index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove import map from `index.html` so dependencies resolve from `node_modules`

## Testing
- `npm install`
- `npm test`
- `npm run dev` *(fails: No matching export in "dataconnect-generated/js/default-connector/esm/index.esm.js" for import "listFavoriteTherapists" and similar)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc70ce90832b904233cd8e8a9326