### PR TITLE
Display startup errors on initial load

### DIFF
--- a/components/StartupError.tsx
+++ b/components/StartupError.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface StartupErrorProps {
+  message: string;
+}
+
+const StartupError: React.FC<StartupErrorProps> = ({ message }) => (
+  <div className="flex items-center justify-center min-h-screen bg-red-50 p-4">
+    <div className="bg-white p-6 rounded shadow max-w-md text-center">
+      <h1 className="text-2xl font-bold mb-4 text-red-600">Something went wrong</h1>
+      <p className="text-gray-700">{message}</p>
+    </div>
+  </div>
+);
+
+export default StartupError;

--- a/index.tsx
+++ b/index.tsx
@@ -4,18 +4,28 @@ import App from './App';
 import './index.css';
 import '@fortawesome/fontawesome-free/css/all.css';
 import 'leaflet/dist/leaflet.css';
+import StartupError from './components/StartupError';
 
-const rootElement = document.getElementById('root');
-if (!rootElement) {
-  throw new Error("Could not find root element to mount to. Ensure an element with id 'root' exists in your HTML.");
+try {
+  const rootElement = document.getElementById('root');
+  if (!rootElement) {
+    throw new Error("Could not find root element to mount to. Ensure an element with id 'root' exists in your HTML.");
+  }
+
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+} catch (error) {
+  const rootElement = document.getElementById('root');
+  if (rootElement) {
+    const root = ReactDOM.createRoot(rootElement);
+    const message = error instanceof Error ? error.message : String(error);
+    root.render(<StartupError message={message} />);
+  }
 }
-
-const root = ReactDOM.createRoot(rootElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
 
 // PWA service worker registration is now handled automatically by vite-plugin-pwa.
 // The manual registration block has been removed.


### PR DESCRIPTION
## Summary
- show a friendly overlay when startup fails
- wrap root render in try/catch

## Testing
- `npx vitest run --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_689500b7f4c8832b95ef1d6335736337