### PR TITLE
Gracefully handle missing Firebase config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,8 @@ import { UserRole } from './types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { firebaseConfig } from './firebase';
+import { FirebaseConfigMissing } from './components/FirebaseConfigMissing';
 
 
 // Lazy load page components for better performance
@@ -164,10 +166,14 @@ const queryClient = new QueryClient({
 });
 
 const App: React.FC = () => {
+  if (!firebaseConfig.apiKey || !firebaseConfig.projectId) {
+    return <FirebaseConfigMissing />;
+  }
+
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <LanguageProvider> 
+        <LanguageProvider>
           <AuthProvider>
             <ReactRouterDOM.BrowserRouter>
               <AppContent />

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ TheraWay is a comprehensive mental health web application designed to connect cl
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and supply Firebase and Data Connect credentials.
+1. Copy `.env.example` to `.env` and supply Firebase and Data Connect credentials:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Then edit `.env` and fill in the Firebase configuration values for your project.
 2. Install dependencies: `npm install`
 3. Start the development server: `npm run dev`
 4. Visit `http://localhost:5173` and verify the landing page loads.

--- a/components/FirebaseConfigMissing.tsx
+++ b/components/FirebaseConfigMissing.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export const FirebaseConfigMissing: React.FC = () => (
+  <div className="flex items-center justify-center min-h-screen bg-background text-textOnLight">
+    Firebase config missing
+  </div>
+);
+

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp, getApp, getApps } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
+import { initializeApp, getApp, getApps, type FirebaseApp } from "firebase/app";
+import { getAuth, type Auth } from "firebase/auth";
+import { getFirestore, type Firestore } from "firebase/firestore";
+import { getStorage, type FirebaseStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -11,20 +11,24 @@ const firebaseConfig = {
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
+let storage: FirebaseStorage | undefined;
 
-if (!firebaseConfig.apiKey || !firebaseConfig.projectId) {
-  throw new Error("Firebase configuration environment variables are not set. Please create a .env file based on .env.example and fill in your Firebase project details.");
+if (firebaseConfig.apiKey && firebaseConfig.projectId) {
+  console.log(
+    `%cFirebase config loaded with Project ID: ${firebaseConfig.projectId}. Ensure Firestore is ENABLED in the Firebase Console for this project.`,
+    'color: green; font-weight: bold; font-size: 12px;'
+  );
+  app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+  auth = getAuth(app);
+  db = getFirestore(app);
+  storage = getStorage(app);
+} else {
+  console.warn(
+    "Firebase configuration environment variables are not set. Firebase features will be disabled."
+  );
 }
-
-console.log(
-  `%cFirebase config loaded with Project ID: ${firebaseConfig.projectId}. Ensure Firestore is ENABLED in the Firebase Console for this project.`,
-  'color: green; font-weight: bold; font-size: 12px;'
-);
-
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-
-const auth = getAuth(app);
-const db = getFirestore(app);
-const storage = getStorage(app);
 
 export { app, auth, db, storage, firebaseConfig };


### PR DESCRIPTION
## Summary
- Guard against missing environment variables and skip Firebase initialization with warnings
- Show a "Firebase config missing" fallback when config is absent
- Document copying `.env.example` and filling Firebase settings in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898fd0992f0832ba50b351f65d9fd32