### PR TITLE
Improve startup error feedback

### DIFF
--- a/components/StartupError.tsx
+++ b/components/StartupError.tsx
@@ -7,8 +7,17 @@ interface StartupErrorProps {
 const StartupError: React.FC<StartupErrorProps> = ({ message }) => (
   <div className="flex items-center justify-center min-h-screen bg-red-50 p-4">
     <div className="bg-white p-6 rounded shadow max-w-md text-center">
-      <h1 className="text-2xl font-bold mb-4 text-red-600">Something went wrong</h1>
-      <p className="text-gray-700">{message}</p>
+      <h1 className="text-2xl font-bold mb-4 text-red-600">Application failed to start</h1>
+      <p className="text-gray-700 mb-4">An unexpected error occurred during startup:</p>
+      <p className="text-gray-700 mb-4">{message}</p>
+      <a
+        href="https://github.com/TheraWay/TheraWayV3#setup"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 underline"
+      >
+        View setup documentation
+      </a>
     </div>
   </div>
 );

--- a/index.test.tsx
+++ b/index.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./App', () => ({ default: () => <div /> }));
+vi.mock('./index.css', () => ({}));
+vi.mock('@fortawesome/fontawesome-free/css/all.css', () => ({}));
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+
+// Mock react-dom/client to throw on first createRoot call and succeed on subsequent calls
+vi.mock('react-dom/client', async () => {
+  const actual = await vi.importActual<typeof import('react-dom/client')>('react-dom/client');
+  let shouldThrow = true;
+  const createRoot = (container: Element | DocumentFragment) => {
+    if (shouldThrow) {
+      shouldThrow = false;
+      throw new Error('test error');
+    }
+    return actual.createRoot(container);
+  };
+  return {
+    ...actual,
+    createRoot,
+    default: { ...actual, createRoot },
+  };
+});
+
+describe('index startup error handling', () => {
+  it('renders StartupError when root render fails', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await import('./index');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(document.body.innerHTML).toContain('View setup documentation');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/index.tsx
+++ b/index.tsx
@@ -19,6 +19,9 @@ try {
     </React.StrictMode>
   );
 } catch (error) {
+  // Log the full error details to help with troubleshooting
+  console.error('Application failed to start:', error);
+
   const rootElement = document.getElementById('root');
   if (rootElement) {
     const root = ReactDOM.createRoot(rootElement);


### PR DESCRIPTION
## Summary
- log detailed startup errors to the console
- show clearer StartupError message with documentation link
- add test ensuring render failures display StartupError

## Testing
- `npx vitest run --environment jsdom`
- `npm run build` *(fails: Argument of type 'Firestore | undefined' is not assignable to parameter of type 'Firestore')*

------
https://chatgpt.com/codex/tasks/task_e_689aa28f7ad0832ba1cedf22b60869cc